### PR TITLE
Reset view position after the shiving animation

### DIFF
--- a/explosionfield/src/main/java/tyrantgit/explosionfield/ExplosionField.java
+++ b/explosionfield/src/main/java/tyrantgit/explosionfield/ExplosionField.java
@@ -105,6 +105,20 @@ public class ExplosionField extends View {
 
             }
         });
+	animator.addListener(new AnimatorListener() {
+		@Override
+		public void onAnimationStart(Animator animation) { }
+		@Override
+		public void onAnimationRepeat(Animator animation) { }
+		@Override
+		public void onAnimationEnd(Animator animation) {
+			view.clearAnimation();
+			view.setTranslationX(0);
+			view.setTranslationY(0);
+		}
+		@Override
+		public void onAnimationCancel(Animator animation) { }
+	});
         animator.start();
         view.animate().setDuration(150).setStartDelay(startDelay).scaleX(0f).scaleY(0f).alpha(0f).start();
         explode(Utils.createBitmapFromView(view), r, startDelay, ExplosionAnimator.DEFAULT_DURATION);


### PR DESCRIPTION
This is mandatory to reset the view position (setTranslationX and setTranslationY both to 0) because
after the shiving animation, the last two random translations applied will be retained. 
