### PR TITLE
Update sample to showcase bitmap explosion capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ ExplosionField explosionField = ...;
 explosionField.explode(view);
 ```
 
+explosive effects can also be applied directly to bitmaps (with provided bounds) using:
+
+```java
+ExplosionField explosionField = ...;
+explosionField.explode(bitmap, bound, startDelay, duration);
+```
+
 ## License
 
     Copyright 2015 tyrantgit

--- a/app/src/main/java/tyrantgit/sample/MainActivity.java
+++ b/app/src/main/java/tyrantgit/sample/MainActivity.java
@@ -1,25 +1,33 @@
 package tyrantgit.sample;
 
 import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
 import tyrantgit.explosionfield.ExplosionField;
+import tyrantgit.explosionfield.Utils;
 
 
-public class MainActivity extends Activity {
+public class MainActivity extends Activity implements View.OnTouchListener {
 
     private ExplosionField mExplosionField;
+    private View root;
+    private int size = Utils.dp2Px(50);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         mExplosionField = ExplosionField.attach2Window(this);
-        addListener(findViewById(R.id.root));
+        root = findViewById(R.id.root);
+        addListener(root);
     }
 
     private void addListener(View root) {
@@ -35,6 +43,7 @@ public class MainActivity extends Activity {
                 public void onClick(View v) {
                     mExplosionField.explode(v);
                     v.setOnClickListener(null);
+                    v.setClickable(false);
                 }
             });
         }
@@ -69,5 +78,65 @@ public class MainActivity extends Activity {
             root.setScaleY(1);
             root.setAlpha(1);
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        root.setOnTouchListener(this);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        root.setOnTouchListener(null);
+    }
+
+    float lastX, lastY;
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+        Bitmap tmp = BitmapFactory.decodeResource(getResources(), R.drawable.p5);
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            lastX = event.getX(); lastY = event.getY();
+            if (tmp == null) return true;
+            int x = (int) lastX, y = (int) lastY;
+            Rect r = new Rect(x - size, y - size, x + size, y + size);
+            mExplosionField.explode(tmp, r, 0, 0x300);
+            return true;
+        } else if(event.getAction() == MotionEvent.ACTION_MOVE) {
+            float distance = getDistance(lastX, lastY, event);
+            if (distance < size/2) {
+                return false;
+            }
+            lastX = event.getX(); lastY = event.getY();
+            if (tmp == null) return true;
+            int x = (int) lastX, y = (int) lastY;
+            Rect r = new Rect(x - size, y - size, x + size, y + size);
+            mExplosionField.explode(tmp, r, 0, 0x300);
+            return true;
+        }
+        return false;
+    }
+
+    float getDistance(float startX, float startY, MotionEvent ev) {
+        float distanceSum = 0;
+        final int historySize = ev.getHistorySize();
+        for (int h = 0; h < historySize; h++) {
+            // historical point
+            float hx = ev.getHistoricalX(0, h);
+            float hy = ev.getHistoricalY(0, h);
+            // distance between startX,startY and historical point
+            float dx = (hx - startX);
+            float dy = (hy - startY);
+            distanceSum += Math.sqrt(dx * dx + dy * dy);
+            // make historical point the start point for next loop iteration
+            startX = hx;
+            startY = hy;
+        }
+        // add distance from last historical point to event's point
+        float dx = (ev.getX(0) - startX);
+        float dy = (ev.getY(0) - startY);
+        distanceSum += Math.sqrt(dx * dx + dy * dy);
+        return distanceSum;
     }
 }

--- a/app/src/main/java/tyrantgit/sample/MainActivity.java
+++ b/app/src/main/java/tyrantgit/sample/MainActivity.java
@@ -106,6 +106,8 @@ public class MainActivity extends Activity implements View.OnTouchListener {
         } else if(event.getAction() == MotionEvent.ACTION_MOVE) {
             float distance = getDistance(lastX, lastY, event);
             if (distance < size/2) {
+                // let's not explode for every move you make !!
+                // limit the explosion to a movement distance of half the explosion size
                 return false;
             }
             lastX = event.getX(); lastY = event.getY();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -72,7 +72,7 @@
         android:layout_width="match_parent"
         android:gravity="center"
         android:layout_marginTop="48dp"
-        android:text="click to destroy"
+        android:text="click to destroy\nor swipe anywhere on the empty area"
         android:layout_height="wrap_content" />
 
 


### PR DESCRIPTION
The bitmap explosion capability was hidden in the code and not showcased in the sample.
Added touch listener on the entire MainActivity root view to showcase the direct bitmap explosion capability - triggered on touch DOWN and MOVE events.
